### PR TITLE
Library can disconnect from Pusher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+test/


### PR DESCRIPTION
Sends a control frame to Pusher and then exits from the runLoop and readLoop.
