### PR TITLE
Client events

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -7,6 +7,7 @@ import (
 type Channel struct {
 	Subscribed bool
 	Name       string
+	*connection
 }
 
 func (self *Channel) isPrivate() bool {
@@ -15,4 +16,16 @@ func (self *Channel) isPrivate() bool {
 
 func (self *Channel) isPresence() bool {
 	return s.HasPrefix(self.Name, "presence-")
+}
+
+func (self *Channel) Trigger(event string, data interface{}) {
+	payload, err := encode(event, data, &self.Name)
+
+	log.Println(string(payload))
+
+	if err != nil {
+		panic(err)
+	}
+
+	self.connection.send(payload)
 }


### PR DESCRIPTION
Subscription returns a channel object, on which one can trigger events. The connection object is now accessible as a property of channel and client
